### PR TITLE
Update dl4j version and replace IMin & IMax classes

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "\U0001F4AC FAQ"
+    url: https://github.com/CertifaiAI/CertifAI-Knowledge-Base/wiki
+    about: "Please check your questions/issues here. Your questions may already have been answered. \U0001F642"

--- a/.github/workflows/auto_comment.yml
+++ b/.github/workflows/auto_comment.yml
@@ -1,0 +1,21 @@
+name: Issues Auto Comment
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bubkoo/auto-comment@v1.0.7
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issuesOpenedReactions: 'hooray, +1'
+          issuesOpenedComment: >
+            👋 @{{ author }}
+            
+            Thank you for raising an issue. We will investigate into the matter and get back to you as soon as possible.
+            
+            Please make sure you have given us as much context as possible.

--- a/dl4j-labs/src/main/java/ai/certifai/solution/nd4j/Ex8_IndexReductionOperations.java
+++ b/dl4j-labs/src/main/java/ai/certifai/solution/nd4j/Ex8_IndexReductionOperations.java
@@ -18,7 +18,7 @@
 package ai.certifai.solution.nd4j;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.impl.indexaccum.IMin;
+import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
 import org.nd4j.linalg.factory.Nd4j;
 
 public class Ex8_IndexReductionOperations {
@@ -53,7 +53,7 @@ public class Ex8_IndexReductionOperations {
         System.out.println(maxIndexHor);
 
         //Index of the min value, along dimension 0
-        INDArray minIndexAlongDim0 = Nd4j.getExecutioner().exec(new IMin(myArray, 0));
+        INDArray minIndexAlongDim0 = Nd4j.getExecutioner().exec(new ArgMin(myArray, 0))[0];
         System.out.println(BLACK_BOLD + "\nGet the index of minimum value along dimension 0:" + ANSI_RESET);
         System.out.println(BLUE_BOLD + "Nd4j.getExecutioner().exec(new IMin(myArray, 0))" + ANSI_RESET);
         System.out.println(minIndexAlongDim0);

--- a/dl4j-labs/src/main/java/ai/certifai/solution/recurrent/basic/BasicRNNExample.java
+++ b/dl4j-labs/src/main/java/ai/certifai/solution/recurrent/basic/BasicRNNExample.java
@@ -30,7 +30,7 @@ import org.deeplearning4j.ui.model.stats.StatsListener;
 import org.deeplearning4j.ui.model.storage.InMemoryStatsStorage;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.impl.indexaccum.IMax;
+import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMax;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.RmsProp;
@@ -178,7 +178,7 @@ public class BasicRNNExample
                 // first process the last output of the network to a concrete
                 // neuron, the neuron with the highest output has the highest
                 // chance to get chosen
-                int sampledCharacterIdx = Nd4j.getExecutioner().exec(new IMax(output,1)).getInt(0);
+                int sampledCharacterIdx = Nd4j.getExecutioner().exec(new ArgMax(output,1))[0].getInt(0);
 
                 //print the chosen output
                 System.out.print(LEARNSTRING_CHARS_LIST.get(sampledCharacterIdx));

--- a/dl4j-labs/src/main/java/ai/certifai/training/nd4j/Ex8_IndexReductionOperations.java
+++ b/dl4j-labs/src/main/java/ai/certifai/training/nd4j/Ex8_IndexReductionOperations.java
@@ -18,7 +18,7 @@
 package ai.certifai.training.nd4j;
 
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.impl.indexaccum.IMin;
+import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMin;
 import org.nd4j.linalg.factory.Nd4j;
 
 public class Ex8_IndexReductionOperations {
@@ -53,7 +53,7 @@ public class Ex8_IndexReductionOperations {
         System.out.println(maxIndexHor);
 
         //Index of the min value, along dimension 0
-        INDArray minIndexAlongDim0 = Nd4j.getExecutioner().exec(new IMin(myArray, 0));
+        INDArray minIndexAlongDim0 = Nd4j.getExecutioner().exec(new ArgMin(myArray, 0))[0];
         System.out.println(BLACK_BOLD + "\nGet the index of minimum value along dimension 0:" + ANSI_RESET);
         System.out.println(BLUE_BOLD + "Nd4j.getExecutioner().exec(new IMin(myArray, 0))" + ANSI_RESET);
         System.out.println(minIndexAlongDim0);

--- a/dl4j-labs/src/main/java/ai/certifai/training/recurrent/basic/BasicRNNExample.java
+++ b/dl4j-labs/src/main/java/ai/certifai/training/recurrent/basic/BasicRNNExample.java
@@ -27,7 +27,7 @@ import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.ui.api.UIServer;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
-import org.nd4j.linalg.api.ops.impl.indexaccum.IMax;
+import org.nd4j.linalg.api.ops.impl.indexaccum.custom.ArgMax;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.RmsProp;
@@ -180,7 +180,7 @@ public class BasicRNNExample
                 // first process the last output of the network to a concrete
                 // neuron, the neuron with the highest output has the highest
                 // chance to get chosen
-                int sampledCharacterIdx = Nd4j.getExecutioner().exec(new IMax(output), 1).getInt(0);
+                int sampledCharacterIdx = Nd4j.getExecutioner().exec(new ArgMax(output,1))[0].getInt(0);
 
                 //print the chosen output
                 System.out.print(LEARNSTRING_CHARS_LIST.get(sampledCharacterIdx));

--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,11 @@
         <shadedClassifier>bin</shadedClassifier>
 
         <java.version>1.8</java.version>
-        <nd4j.version>1.0.0-beta7</nd4j.version>
-        <dl4j.version>1.0.0-beta7</dl4j.version>
-        <datavec.version>1.0.0-beta7</datavec.version>
+        <nd4j.version>1.0.0-M1.1</nd4j.version>
+        <dl4j.version>1.0.0-M1.1</dl4j.version>
+        <datavec.version>1.0.0-M1.1</datavec.version>
 
-        <javacv.version>1.5.3</javacv.version>
+        <javacv.version>1.5.5</javacv.version>
         <ffmpeg.version>3.2.1-1.3</ffmpeg.version>
         <zip4j.version>2.2.6</zip4j.version>
         <slf4j.version>2.0.0-alpha1</slf4j.version>


### PR DESCRIPTION
# Description

- Update the dependencies versions in `pom.xml`.
  - `nd4j`, `dl4j` & `datavec`: from `1.0.0-beta7` to `1.0.0-M1.1`
  - `javacv`: from `1.5.3` to `1.5.5`
- Replace `IMin` & `IMax` imported library classes which are not available in latest dl4j version with `ArgMin` & `ArgMax`

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

