### PR TITLE
Fix import classes from wrong package

### DIFF
--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/facial_recognition/identification/feature/VGG16FeatureProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/facial_recognition/identification/feature/VGG16FeatureProvider.java
@@ -17,9 +17,9 @@
 
 package ai.certifai.training.facial_recognition.identification.feature;
 
-import ai.certifai.solution.facial_recognition.detection.FaceLocalization;
-import ai.certifai.solution.facial_recognition.detection.OpenCV_DeepLearningFaceDetector;
-import ai.certifai.solution.facial_recognition.identification.Prediction;
+import ai.certifai.training.facial_recognition.detection.FaceLocalization;
+import ai.certifai.training.facial_recognition.detection.OpenCV_DeepLearningFaceDetector;
+import ai.certifai.training.facial_recognition.identification.Prediction;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Rect;
 import org.bytedeco.opencv.opencv_core.Size;


### PR DESCRIPTION
# Description
- These classes in training java file should be imported from `ai.certifai.training.facial_recognition` package.
https://github.com/CertifaiAI/cdle-traininglabs/blob/5e24891656cd294fd995fe28c2a05648e0fb62d4/dl4j-cv-labs/src/main/java/ai/certifai/training/facial_recognition/identification/feature/VGG16FeatureProvider.java#L20-L22

# Issue
- Error trigger when running `dl4j-cv-labs/src/main/java/ai/certifai/training/facial_recognition/FaceRecognitionImage.java` and `dl4j-cv-labs/src/main/java/ai/certifai/training/facial_recognition/FaceRecognitionVideo.java`.

> Caused by: java.lang.NullPointerException
>         at ai.certifai.training.facial_recognition.FaceRecognitionImage.labelIndividual(FaceRecognitionImage.java:169)
>         at ai.certifai.training.facial_recognition.FaceRecognitionImage.main(FaceRecognitionImage.java:113)
>         ... 5 more

## Type of change

Please delete options that are not relevant.

- [ ] New Exercise
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tested on?

- [x] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

